### PR TITLE
Switch to readiness probe

### DIFF
--- a/imagenet/handler.py
+++ b/imagenet/handler.py
@@ -23,7 +23,7 @@ tf.get_logger().setLevel('ERROR')
 model = resnet50.ResNet50(weights='imagenet')
 
 def handle(event, context):
-    if event.path == "/health" and model is not None:
+    if event.path == "/ready" and model is not None:
         return {
             "statusCode": "200",
             "body": "ready"

--- a/stack.yml
+++ b/stack.yml
@@ -6,16 +6,17 @@ functions:
   imagenet:
     lang: python3-http-debian
     handler: ./imagenet
-    image: alexellis2/imagenet:0.0.11
+    image: alexellis2/imagenet:0.0.12
     build_args:
       TEST_ENABLED: false
     environment:
       TF_CPP_MIN_LOG_LEVEL: 3
+      ready_path: /ready
     # OpenFaaS Pro annotations
     annotations:
-      com.openfaas.health.http.path: "/health"
-      com.openfaas.health.http.initialDelay: "5s"
-      com.openfaas.health.http.periodSeconds: "2s"
+      com.openfaas.ready.http.path: "/_/ready"
+      com.openfaas.ready.http.initialDelay: "5s"
+      com.openfaas.ready.http.periodSeconds: "2s"
 
 configuration:
   templates:


### PR DESCRIPTION
## Description
OpenFaaS has added support for readiness probes. Switch to readiness probes to indicate this function is not ready while fetching the model.

## Context
This function is used in the fan-out fan-in pattern post on the OpenFaaS blog and needs to be updated to so it can be used with the OpenFaaS readiness checks.

## How has this been tested
Deployed the function and verified the pod becomes ready after the specified delay.

![Screenshot 2022-10-27 at 11 47 29](https://user-images.githubusercontent.com/16267532/198252973-f7b013b0-14cd-463b-98f2-f3e4c078e964.png)

Invoked the function successfully.